### PR TITLE
Fix row ID collision causing cells to stack inside existing rows

### DIFF
--- a/js/statehandler.js
+++ b/js/statehandler.js
@@ -1,16 +1,21 @@
 import { RESULT_TABLE_LENGTH, TD_ARRAY_INDEXES, ADDITIONAL_CELL_DATA_KEYS } from './constants.js';
 
 let calculationState = [];
+// Monotonically increasing counter — never decremented on delete,
+// so row IDs are always unique and never collide with existing rows.
+let rowCounter = 0;
 
 export function addResultToArray(result) {
   const { investment, finalProfit, finalCapital, finalPercentage, years } = result;
 
+  rowCounter++;
   calculationState.push({
     investment,
     finalProfit,
     finalCapital,
     finalPercentage,
     years,
+    rowId: rowCounter,
   });
 
   addRow(calculationState);
@@ -18,7 +23,8 @@ export function addResultToArray(result) {
 
 function addRow(calculationData) {
   const rowIndex = calculationData.length - 1;
-  const thisTrId = `tr${calculationData.length}`;
+  const stateItem = calculationData[rowIndex];
+  const thisTrId = `tr${stateItem.rowId}`;
 
   const tr = document.createElement('tr');
   tr.setAttribute('id', thisTrId);
@@ -64,9 +70,12 @@ function deleteRow(event) {
   const row = event.target.closest('tr');
 
   if (row) {
-    // Remove from state array to prevent memory leak and index mismatch
-    const rowIndex = parseInt(row.id.replace('tr', ''), 10) - 1;
-    calculationState.splice(rowIndex, 1);
+    // Find the state entry by its stored rowId (not by array index derived from DOM id)
+    const rowId = parseInt(row.id.replace('tr', ''), 10);
+    const stateIndex = calculationState.findIndex((item) => item.rowId === rowId);
+    if (stateIndex !== -1) {
+      calculationState.splice(stateIndex, 1);
+    }
     row.remove();
   }
 }


### PR DESCRIPTION
When a row was deleted, the next added row could receive an ID that already belonged to a remaining DOM row (since the ID was derived from calculationState.length, which shrinks on delete). appendChildren() would then target the existing element instead of the new <tr>, appending all cells into one row side-by-side.

Fix:
- Introduce a monotonically increasing rowCounter that never decrements, so every new row gets a globally unique ID
- Store rowId on each state item so deleteRow() can find the correct state entry via findIndex() instead of deriving the index from the DOM ID (which is no longer the same as the array index)

https://claude.ai/code/session_01NFPZR6E21Mu6gqxn1cuJJ2